### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issues-to-projects.yml
+++ b/.github/workflows/issues-to-projects.yml
@@ -10,6 +10,9 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      repository-projects: write
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/bbc/sqs-extended/security/code-scanning/1](https://github.com/bbc/sqs-extended/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow interacts with issues and potentially GitHub projects, we will grant the minimal required permissions: `issues: write` and `repository-projects: write`. These permissions allow the workflow to add issues to a project without granting unnecessary access to other resources.

The `permissions` block will be added at the job level (`add-to-project`) to ensure it applies only to this specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
