### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,8 @@
 name: 'Close stale issues and PRs'
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 on:
   schedule:
     - cron: '30 1 * * *'


### PR DESCRIPTION
Potential fix for [https://github.com/bbc/sqs-extended/security/code-scanning/2](https://github.com/bbc/sqs-extended/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's purpose (managing stale issues and pull requests), the required permissions are likely `contents: read`, `issues: write`, and `pull-requests: write`. These permissions allow the workflow to read repository contents, comment on issues, and manage pull requests without granting unnecessary access.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs, as there is only one job (`stale`) in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
